### PR TITLE
Add Mac OS X support, fix problems I encountered while debugging

### DIFF
--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -430,6 +430,20 @@ install_file() {
       info "installing with sh..."
       sh "$2"
       ;;
+    "dmg" )
+      info "installing with installer..."
+      hdiutil attach $2 
+      installer -verboseR -target / -package /Volumes/puppet-${version}/puppet-${version}.pkg
+      # code via stackoverflow, woot -- installer might not be done at exit
+      # http://stackoverflow.com/questions/18752257/delay-from-osx-installer
+      flag=1
+      while [ $flag -ne 0 ]
+          do
+              sleep 1
+              hdiutil unmount /Volumes/puppet-${version}
+              flag=$?
+          done
+      ;;
     *)
       critical "Unknown filetype: $1"
       report_bug
@@ -478,7 +492,7 @@ case $platform in
   "mac_os_x")
     info "Mac OS X platform! You need some DMGs..."
     filetype="dmg"
-    filename="puppet-XXX.dmg"
+    filename="puppet-${version}.dmg"
     download_url="http://downloads.puppetlabs.com/mac/${filename}"
     ;;
   *)


### PR DESCRIPTION
I left these as separate commits in case you want some but not all of it -- the first two are DRY as we're building up the filenames to download and fixups for error checking; the third is a hokey-yet-functional installation for Mac OS X dmg from http://downloads.puppetlabs.com/mac/
