### PR TITLE
Install with apt relies on puppet-common

### DIFF
--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -416,7 +416,7 @@ install_file() {
       info "installing with dpkg..."
       dpkg -i "$2"
       apt-get update -y
-      apt-get install -y "puppet=$version-1puppetlabs1"
+      apt-get install -y "puppet-common=$version-1puppetlabs1" "puppet=$version-1puppetlabs1"
       ;;
     "solaris")
       info "installing with pkgadd..."


### PR DESCRIPTION
Dpkg complains about puppet-common being installed with a wrong/newer version. This forces the use of puppet-common and fixes the error.

The following error happened: 

The following packages have unmet dependencies:
 puppet : Depends: puppet-common (= 3.4.2-1puppetlabs1) but 3.4.3-1puppetlabs1 is to be installed
E: Unable to correct problems, you have held broken packages.
15:29:34 -0300 CRIT: Installation failed
15:29:34 -0300 CRIT: Please file a bug report at https://github.com/petems/puppet-install-shell/
15:29:34 -0300 CRIT:
15:29:34 -0300 CRIT: Version: 3.4.2
15:29:34 -0300 CRIT: Platform: ubuntu
15:29:34 -0300 CRIT: Platform Version: 12.10
15:29:34 -0300 CRIT: Machine: x86_64
15:29:34 -0300 CRIT: OS: Linux
15:29:34 -0300 CRIT:
15:29:34 -0300 CRIT: Please detail your operating system type, version and any other relevant details
