### PR TITLE
Added Arch linux support. Old curl ensure ssl fix. Removed do_python

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,4 +54,15 @@ Vagrant.configure("2") do |config|
   config.vm.define "arch1403" do |arch1404|
     arch1404.vm.box = "cameronmalek/arch1403"
   end
+
+#  Shared folder not available. Tested with:
+#   $ curl https://raw.githubusercontent.com/petems/puppet-install-shell/master/install_puppet.sh | sudo sh
+#
+#  config.vm.define "freebsd10" do |freebsd10|
+#    freebsd10.vm.box = "chef/freebsd-10.0"
+#  end
+#
+#  config.vm.define "freebsd9" do |freebsd9|
+#    freebsd9.vm.box = "chef/freebsd-9.2"
+#  end
 end

--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -467,6 +467,30 @@ case $platform in
       pacman -Sy --noconfirm "community/puppet>=$version"
     fi
     ;;
+  "freebsd")
+    info "Installing Puppet $version for FreeBSD..."
+    if test "$version" != "latest"; then
+      warn "In FreeBSD installation of older versions is not possible. Version is set to latest."
+    fi
+    case $major_version in
+      "9")
+        have_pkg=`grep -sc '^WITH_PKGNG' /etc/make.conf`
+        if test "$have_pkg" = 1; then
+          pkg install -y sysutils/puppet
+        else
+          pkg_add -rF puppet
+        fi
+        ;;
+      "10")
+        pkg install -y sysutils/puppet
+        ;;
+      *)
+        critical "Sorry FreeBSD $major_version is not supported yet!"
+        report_bug
+        exit 1
+        ;;
+    esac
+    ;;
   *)
     info "Downloading Puppet $version for ${platform}..."
     case $platform in


### PR DESCRIPTION
Resolves #20 and resolves #21. 
For Arch linux:
Note that when supplying version, it only ensures that at least that version or later is installed. Arch linux doesn't support old packages.
For FreeBSD:
I don't know how to install a specific version (yet).. would like to hear suggestions!
