### PR TITLE
We still ned to set the codename

### DIFF
--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -569,7 +569,7 @@ case $platform in
           "5") deb_codename="lenny";;
           "6") deb_codename="squeeze";;
           "7") deb_codename="wheezy";;
-          "8") warn "Puppet only offers Puppet 4 packages for Jessie, so only 3.7.2 package avaliable"
+          "8") deb_codename="jessie"; warn "Puppet only offers Puppet 4 packages for Jessie, so only 3.7.2 package avaliable"
           no_puppetlab_repo_download='yes';;
         esac
         filetype="deb"


### PR DESCRIPTION
There is a case statement on line 424 which checks $deb_codename and sets the version according
to this check, so we need to set it anyway.