### PR TITLE
Add compatibility for Puppet 4.7.1 and 4.8.0

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -204,7 +204,10 @@ else
       puppet_agent_version='1.6.2'
       ;;
     4.7.*)
-      puppet_agent_version='1.7.0'
+      puppet_agent_version='1.7.1'
+      ;;
+    4.8.*)
+      puppet_agent_version='1.8.0'
       ;;
     *)
       critical "Unable to match requested puppet version to puppet-agent version - Check http://docs.puppetlabs.com/puppet/latest/reference/about_agent.html"


### PR DESCRIPTION
Puppet silently released puppet-agent 1.7.1 a couple of weeks ago (it's not in the docs but it's in the repos), as well as 1.8.0 just a couple of days ago. This adds compatibility for both 😄 