### PR TITLE
Add option to install puppet 4.9

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -209,6 +209,9 @@ else
     4.8.*)
       puppet_agent_version='1.8.2'
       ;;
+    4.9.*)
+      puppet_agent_version='1.9.0'
+      ;;
     *)
       critical "Unable to match requested puppet version to puppet-agent version - Check http://docs.puppetlabs.com/puppet/latest/reference/about_agent.html"
       report_bug


### PR DESCRIPTION
Add case statement for newly releases puppet 4.9 and it to puppet agent version 1.9.0.

closes #71