### PR TITLE
Use puppet-agent-1.7.2 instead of 1.7.1

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -204,7 +204,7 @@ else
       puppet_agent_version='1.6.2'
       ;;
     4.7.*)
-      puppet_agent_version='1.7.1'
+      puppet_agent_version='1.7.2'
       ;;
     4.8.*)
       puppet_agent_version='1.8.2'


### PR DESCRIPTION
`puppet-agent` 1.7.2 is a bugfix release that still includes Puppet 4.7.1 but updates other members of the `puppet-agent` bundle, such as Hiera and Facter.
https://docs.puppet.com/puppet/4.7/release_notes_agent.html#puppet-agent-172