### PR TITLE
Use puppet-agent-1.8.3 instead of 1.8.2

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -207,7 +207,7 @@ else
       puppet_agent_version='1.7.1'
       ;;
     4.8.*)
-      puppet_agent_version='1.8.2'
+      puppet_agent_version='1.8.3'
       ;;
     4.9.*)
       puppet_agent_version='1.9.0'


### PR DESCRIPTION
`puppet-agent` 1.8.3 is a bugfix release that still includes Puppet 4.8.2 but updates Facter from 3.5.0 to 3.5.1.
https://docs.puppet.com/puppet/4.8/release_notes_agent.html#puppet-agent-183