### PR TITLE
Bumping 4.9.x version to latest

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -210,7 +210,7 @@ else
       puppet_agent_version='1.8.2'
       ;;
     4.9.*)
-      puppet_agent_version='1.9.1'
+      puppet_agent_version='1.9.2'
       ;;
     *)
       critical "Unable to match requested puppet version to puppet-agent version - Check http://docs.puppetlabs.com/puppet/latest/reference/about_agent.html"


### PR DESCRIPTION
Puppet 4.9.3 was released on 27-Feb-2017, and along with it a new version (1.9.2) of the Puppet agent bundle.
https://docs.puppet.com/puppet/4.9/release_notes_agent.html