### PR TITLE
Bumping 4.9.x version to latest

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -213,7 +213,7 @@ else
       puppet_agent_version='1.8.3'
       ;;
     4.9.*)
-      puppet_agent_version='1.9.2'
+      puppet_agent_version='1.9.3'
       ;;
     *)
       critical "Unable to match requested puppet version to puppet-agent version - Check http://docs.puppetlabs.com/puppet/latest/reference/about_agent.html"


### PR DESCRIPTION
Puppet 4.9.4 was released on 09-Mar-2017, and along with it a new version (1.9.3) of the Puppet agent bundle.
https://docs.puppet.com/puppet/4.9/release_notes_agent.html