### PR TITLE
Update Puppet Agent to 1.10.3

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -216,7 +216,7 @@ else
       puppet_agent_version='1.9.3'
       ;;
     4.10.*)
-      puppet_agent_version='1.10.2'
+      puppet_agent_version='1.10.3'
       ;;
     *)
       critical "Unable to match requested puppet version to puppet-agent version - Check http://docs.puppetlabs.com/puppet/latest/reference/about_agent.html"


### PR DESCRIPTION
Puppet-Agent 1.10.3 is a bug fix release containing only Puppet 4.10.3, which resolves a bug with custom facts containing `&`.
https://docs.puppet.com/puppet/4.10/release_notes_agent.html