### PR TITLE
Add package version string to debian

### DIFF
--- a/install_puppet_5_agent.sh
+++ b/install_puppet_5_agent.sh
@@ -46,7 +46,7 @@ critical () {
 utopic () {
     warn "There is no utopic release yet, see https://tickets.puppetlabs.com/browse/CPR-92 for progress";
     warn "We'll use the trusty package for now";
-    ubuntu_codename="trusty";
+    deb_codename="trusty";
 }
 
 # Check whether a command exists - returns 0 if it does, 1 if it does not
@@ -438,8 +438,8 @@ install_file() {
       if test "$version" = 'latest'; then
         apt-get install -y puppet-agent
       else
-        if test "x$ubuntu_codename" != "x"; then
-          apt-get install -y "puppet-agent=${puppet_agent_version}-1${ubuntu_codename}"
+        if test "x$deb_codename" != "x"; then
+          apt-get install -y "puppet-agent=${puppet_agent_version}-1${deb_codename}"
         else
           apt-get install -y "puppet-agent=${puppet_agent_version}"
         fi
@@ -503,20 +503,20 @@ case $platform in
       "ubuntu")
         info "Ubuntu platform! Lets get you a DEB..."
         case $platform_version in
-          "12.04") ubuntu_codename="precise";;
-          "12.10") ubuntu_codename="quantal";;
-          "13.04") ubuntu_codename="raring";;
-          "13.10") ubuntu_codename="saucy";;
-          "14.04") ubuntu_codename="trusty";;
-          "15.04") ubuntu_codename="vivid";;
-          "15.10") ubuntu_codename="wily";;
-          "16.04") ubuntu_codename="xenial";;
-          "16.10") ubuntu_codename="yakkety";;
-          "17.04") ubuntu_codename="zesty";;
+          "12.04") deb_codename="precise";;
+          "12.10") deb_codename="quantal";;
+          "13.04") deb_codename="raring";;
+          "13.10") deb_codename="saucy";;
+          "14.04") deb_codename="trusty";;
+          "15.04") deb_codename="vivid";;
+          "15.10") deb_codename="wily";;
+          "16.04") deb_codename="xenial";;
+          "16.10") deb_codename="yakkety";;
+          "17.04") deb_codename="zesty";;
           "14.10") utopic;;
         esac
         filetype="deb"
-        filename="puppet5-release-${ubuntu_codename}.deb"
+        filename="puppet5-release-${deb_codename}.deb"
         download_url="http://apt.puppetlabs.com/${filename}"
         ;;
       "mac_os_x")

--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -46,7 +46,7 @@ critical () {
 utopic () {
     warn "There is no utopic release yet, see https://tickets.puppetlabs.com/browse/CPR-92 for progress";
     warn "We'll use the trusty package for now";
-    ubuntu_codename="trusty";
+    deb_codename="trusty";
 }
 
 # Check whether a command exists - returns 0 if it does, 1 if it does not
@@ -471,8 +471,8 @@ install_file() {
       if test "$version" = 'latest'; then
         apt-get install -y puppet-agent
       else
-        if test "x$ubuntu_codename" != "x"; then
-          apt-get install -y "puppet-agent=${puppet_agent_version}-1${ubuntu_codename}"
+        if test "x$deb_codename" != "x"; then
+          apt-get install -y "puppet-agent=${puppet_agent_version}-1${deb_codename}"
         else
           apt-get install -y "puppet-agent=${puppet_agent_version}"
         fi
@@ -552,20 +552,20 @@ case $platform in
       "ubuntu")
         info "Ubuntu platform! Lets get you a DEB..."
         case $platform_version in
-          "12.04") ubuntu_codename="precise";;
-          "12.10") ubuntu_codename="quantal";;
-          "13.04") ubuntu_codename="raring";;
-          "13.10") ubuntu_codename="saucy";;
-          "14.04") ubuntu_codename="trusty";;
-          "15.04") ubuntu_codename="vivid";;
-          "15.10") ubuntu_codename="wily";;
-          "16.04") ubuntu_codename="xenial";;
-          "16.10") ubuntu_codename="yakkety";;
-          "17.04") ubuntu_codename="zesty";;
+          "12.04") deb_codename="precise";;
+          "12.10") deb_codename="quantal";;
+          "13.04") deb_codename="raring";;
+          "13.10") deb_codename="saucy";;
+          "14.04") deb_codename="trusty";;
+          "15.04") deb_codename="vivid";;
+          "15.10") deb_codename="wily";;
+          "16.04") deb_codename="xenial";;
+          "16.10") deb_codename="yakkety";;
+          "17.04") deb_codename="zesty";;
           "14.10") utopic;;
         esac
         filetype="deb"
-        filename="puppetlabs-release-pc1-${ubuntu_codename}.deb"
+        filename="puppetlabs-release-pc1-${deb_codename}.deb"
         download_url="http://apt.puppetlabs.com/${filename}"
         ;;
       "mac_os_x")

--- a/spec/acceptance/nodesets/debian-8-docker.yml
+++ b/spec/acceptance/nodesets/debian-8-docker.yml
@@ -9,7 +9,6 @@ HOSTS:
     docker_preserve_image: true
     docker_image_commands:
       - apt-get install -yq wget net-tools locales apt-transport-https software-properties-common
-      - locale-gen en en_US en_US.UTF-8
       - echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && DEBIAN_FRONTEND=noninteractive /usr/sbin/update-locale LANG=en_US.UTF-8
       - rm /lib/systemd/system/systemd*udev*
       - rm /lib/systemd/system/getty.target


### PR DESCRIPTION
Updates to allow Debian to give version numbers

    * Before the script didn't specify versions on
    Debian, only Ubuntu
    * This meant it tried to install a vanilla version
    string rather than the actual package name
    * `puppet-agent=5.0.0-1jessie` instead of
    `puppet-agent=5.0.0`