### PR TITLE
Ensure all minor versions are at their latest patch version

### DIFF
--- a/install_puppet_agent.sh
+++ b/install_puppet_agent.sh
@@ -192,7 +192,7 @@ else
       puppet_agent_version='1.2.7'
       ;;
     4.3.*)
-      puppet_agent_version='1.3.5'
+      puppet_agent_version='1.3.6'
       ;;
     4.4.*)
       puppet_agent_version='1.4.2'
@@ -205,9 +205,6 @@ else
       ;;
     4.7.*)
       puppet_agent_version='1.7.2'
-      ;;
-    4.8.0)
-      puppet_agent_version='1.8.0'
       ;;
     4.8.*)
       puppet_agent_version='1.8.3'


### PR DESCRIPTION
I quickly went through the packages [here](http://yum.puppetlabs.com/el/7/PC1/x86_64/) and saw 1.3.x was not at the latest.

At the same time I propose to remove the locked 4.8.0 version; https://github.com/petems/puppet-install-shell/issues/69 was the reason for that particular bit, but since numerous newer versions have come out since, I'm thinking it's no longer useful.