### PR TITLE
Puppetlabs release packages have moved permanently

### DIFF
--- a/install_puppet_6_agent.sh
+++ b/install_puppet_6_agent.sh
@@ -487,13 +487,13 @@ case $platform in
         info "Red hat like platform! Lets get you an RPM..."
         filetype="rpm"
         filename="puppet6-release-el-${platform_version}.noarch.rpm"
-        download_url="http://yum.puppetlabs.com/puppet6/${filename}"
+        download_url="http://yum.puppetlabs.com/${filename}"
         ;;
       "fedora")
         info "Fedora platform! Lets get the RPM..."
         filetype="rpm"
         filename="puppet6-release-fedora-${platform_version}.noarch.rpm"
-        download_url="http://yum.puppetlabs.com/puppet6/${filename}"
+        download_url="http://yum.puppetlabs.com/${filename}"
         ;;
       "debian")
         info "Debian platform! Lets get you a DEB..."


### PR DESCRIPTION
The install script fails on Fedora 30 when using the omnibus install
because the release packages on yum.puppetlabs.com have been moved to
the top level. All the current release packages have been copied to
the top level so this will continue to work for older releases.

https://groups.google.com/forum/#!msg/puppet-users/cCsGWKunBe4/OdG0T7LeDAAJ

Signed-off-by: Konrad Scherer <kmscherer@gmail.com>